### PR TITLE
Super simple integration of the TypoPro grunt task.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,184 @@
+
+# QUICK General GitIgnore Notes
+# **************************************************
+# "#" = Comment Line NOTE: You Cannot Put a Comment in the Same Line as a Rule to Be Used
+#							For Example this is BAD: 'ignoreFileName          # Description Comment'
+#
+# Git Ignores are Unrooted. Patterns will match anything at or below a rule's declaration location.
+#
+# "!" may be used to undo a more broad match as long as the containing directory is not entirely ignored.
+#
+# Note on Mac icon files for folders with custom icons: Apple decided that the file name should
+# contain an actual CRLF! The trick is to use the literal ^M control character in the name. But
+# there’s a trick to this trick: you need two ^M characters.
+#
+# **************************************************
+
+
+
+#     Ignore Anywhere Files
+#     ----------------------------
+
+# -------------[ OS Generated ]------------------------ #
+
+._.DS_Store
+.DS_Store
+.DS_Store?
+.icon
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Icon^M^M
+[Tt]humbs.db
+
+
+
+# -------------[ Adobe Dreamweaver Generated ]------------------------ #
+
+dwsync.xml
+
+# -------------[ Adobe Flash Generated ]------------------------ #
+
+RECOVER_*
+
+# -------------[ Bower ]------------------------ #
+
+**/bower_components/
+
+
+
+# -------------[ Eclipse ]------------------------ #
+
+*.pydevproject
+.project
+.metadata
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.classpath
+.settings/
+.loadpath
+
+# -- External tool builders
+.externalToolBuilders/
+
+# -- Locally stored "Eclipse launch configurations"
+*.launch
+
+# -- CDT-specific
+.cproject
+
+# -- PDT-specific
+.buildpath
+
+# -------------[ Flash Builder / Flex Generated ]------------------------ #
+
+.settings/openInBuilder
+
+# -------------[ FlashBuildMachine Generated ]------------------------ #
+
+FBM_LastBuildLog.txt
+Fail_Log.txt
+
+
+# -------------[ JetBrains Apps - IntelliJ IDEA, WebStorm, etc. ]------------------------ #
+
+*.iws
+**/.idea/dictionaries
+**/.idea/jsLibraryMappings.xml
+**/.idea/tasks.xml
+**/.idea/vcs.xml
+**/.idea/workspace.xml
+
+# ___Gradle Support___
+**/.idea/gradle.xml
+**/.idea/libraries
+
+# ___Mongo Explorer plugin___
+**/.idea/mongoSettings.xml
+
+# ___mpeltonen/sbt-idea plugin___
+**/.idea_modules/
+
+# ___JIRA plugin___
+atlassian-ide-plugin.xml
+
+# ___Crashlytics plugin (for Android Studio and IntelliJ)___
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# ___Sensitive or high-churn files___
+**/.idea/dataSources.ids
+**/.idea/dataSources.xml
+**/.idea/dataSources.local.xml
+**/.idea/sqlDataSources.xml
+**/.idea/dynamic.xml
+**/.idea/uiDesigner.xml
+
+
+# -------------[ NodeJS NPM ]------------------------ #
+
+**/node_modules/
+
+
+# -------------[ SASS/SCSS ]------------------------ #
+.sass-cache/
+*.css.map
+
+# ----[ Visual Studio / MonoDevelop Generated ]------- #
+
+*.pidb
+*.suo
+*.svd
+*.user
+*.userprefs
+*.userosscache
+*.sln.docstates
+.vs/
+
+# ----[ Visual Studio Code ]------- #
+
+.vscode/
+
+
+#     Ignore Anywhere Folders -- Keep in mind, these will keep the folder’s out of the repo as well as their content
+#     ----------------------------
+
+.svn
+_[Bb]uilds
+__[Bb]uilds
+__[Bb]uildLogs
+_[Ss]taging
+__[Tt]emp
+_notes
+[Bb]in
+[Cc]ache
+[Oo]bj
+[Ll]ogs
+[Tt]mp
+[Tt]emp
+
+
+#     Targeted Folder Ignores -- Keep in mind, these will keep the folder’s out of the repo as well as their content
+#     ----------------------------
+
+
+
+#     Targeted File Ignores -- Containing Folders will Still be Included in the Repo as Long as One File in them is Included
+#     ----------------------------
+
+
+
+
+#     Maintained Folder Ignores -- Ignore All Content in These Folders, Except the Directory Maintaining Text File
+#     ----------------------------
+
+__Build/*
+!__Build/__BuildDirectory.txt
+
+configs/*
+!configs/__DirectoryInfo.txt

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,0 +1,130 @@
+'use strict';
+//
+//
+// # NOTES
+// ================================================================================================
+// ================================================================================================
+
+
+
+//
+// # GRUNT / NODE	FILE	MATCHING	(GLOBBING)
+// ----------------------------------------------
+//
+// Restrict matching to the content of one directory level down (i.e. single directory nesting):
+//		'SomeRootDirectory/{,*/}*.js'
+// Full Recursion, matching the content files in all subdirectoy levels:
+//		'SomeRootDirectory/**/*.js'
+// Full Recursion, matching All content:
+//		'SomeRootDirectory/**'
+// Skip a directory during recursion:
+//		'!**/SkipThisDirectoryName/**'
+
+
+//
+//
+// # Initialization of Any External Processor Objs
+// ================================================================================================
+// ================================================================================================
+
+
+//
+//
+// # Definition of Grunt Task Handling
+// ================================================================================================
+// ================================================================================================
+
+module.exports = function(grunt)
+{
+	//
+	// # Load Sub-modules (i.e. Grunt Tasks)
+	// (Simplify with "matchdep" or "load-grunt-tasks" or get fancy with "load-grunt-config")
+	// ------------------------------
+
+	// Load All Grunt Task Types Listed in the Node package.json in devDependencies
+	require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+
+	//
+	// # Configure App Structure References
+	// --------------------------------------------------------------------------------------------
+
+	var BuildConfigs = {
+		temp: {
+			root: "__Temp",
+			desktop: "__Temp/Desktop Font Files",
+			web: "__Temp/Web Font Files"
+		}
+	};
+
+
+
+
+	//
+	// # Configure Grunt Tasks
+	// --------------------------------------------------------------------------------------------
+
+	grunt.initConfig({
+		// Read in the Node package.json File So its Content is Available to Processes
+		NodePkg: grunt.file.readJSON('package.json'),
+		BuildConfigs: BuildConfigs,
+
+
+		clean: {
+			full: {
+				options: { 'no-write': false },
+				src: [	'<%= BuildConfigs.temp.root %>'
+				]
+			},
+			full_test: {
+				options: { 'no-write': true },// Don't Actually Delete Anything
+				src: [	'<%= BuildConfigs.temp.root %>'
+				]
+			},
+			strip_to_source: {
+				options: { 'no-write': false },
+				src: [	'<%= BuildConfigs.temp.root %>',
+						'node_modules'
+				]
+			}
+		},
+		// End Clean Task Defs
+
+
+		typopro: {
+			options: {
+				directory: '<%= BuildConfigs.temp.web %>',
+				mergecss: true,
+				fonts: [ "SourceCodePro", "OpenSans" ]
+			}
+		},
+		// End TypoPro Task Defs
+
+	});
+
+
+	//
+	// # Register (Executable) Grunt Task Aliases
+	// --------------------------------------------------------------------------------------------
+
+	// Define the DEFAULT task - executed when running grunt with no arguments
+	grunt.registerTask('default', ['BasicWorkBuild']);
+
+
+	grunt.registerTask('BasicWorkBuild', 'Starts the Development Build Cycle, Express Web Server, and Watches  < DEFAULT >',
+		function() {
+			grunt.task.run([
+				'clean:full',
+				'typopro'
+			]);
+		}
+	);
+
+
+	grunt.registerTask('Nuke', 'Clears All Build Content and Strips Down to Only Source (NPM Install will be Required to Work Again).',
+		function() {
+			grunt.task.run([
+				'clean:strip_to_source'
+			]);
+		}
+	);
+};

--- a/package.json
+++ b/package.json
@@ -1,26 +1,37 @@
 {
-    "name":        "typopro",
-    "version":     "3.6.0",
-    "description": "Fonts for Professional Typography (META)",
-    "homepage":    "https://github.com/rse/typopro",
-    "license":     "MIT AND Apache-2.0 AND OFL-1.1 AND CC0-1.0",
-    "author": {
-        "name":    "Ralf S. Engelschall",
-        "email":   "rse@engelschall.com",
-        "url":     "http://engelschall.com"
-    },
-    "keywords": [
-        "font", "typography", "ttf", "otf", "woff", "eot"
-    ],
-    "repository": {
-        "type":    "git",
-        "url":     "git://github.com/rse/typopro.git"
-    },
-    "bugs": {
-        "url":     "http://github.com/rse/typopro/issues"
-    },
-    "dependencies" : {
-        "typopro-web": "3.6.0",
-        "typopro-dtp": "3.6.0"
-    }
+  "name": "typopro",
+  "version": "3.6.0",
+  "description": "Fonts for Professional Typography (META)",
+  "homepage": "https://github.com/rse/typopro",
+  "license": "MIT AND Apache-2.0 AND OFL-1.1 AND CC0-1.0",
+  "author": {
+    "name": "Ralf S. Engelschall",
+    "email": "rse@engelschall.com",
+    "url": "http://engelschall.com"
+  },
+  "keywords": [
+    "font",
+    "typography",
+    "ttf",
+    "otf",
+    "woff",
+    "eot"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/rse/typopro.git"
+  },
+  "bugs": {
+    "url": "http://github.com/rse/typopro/issues"
+  },
+  "dependencies": {
+    "typopro-web": "3.6.0",
+    "typopro-dtp": "3.6.0"
+  },
+  "devDependencies": {
+    "grunt": "^1.0.1",
+    "grunt-contrib-clean": "^1.1.0",
+    "grunt-typopro": "^1.0.0",
+    "matchdep": "^1.0.1"
+  }
 }


### PR DESCRIPTION
Creates a quick flow in the main TypoPro repo for packaging desired web fonts for migration to a project. Builds package in a clean __Temp dir. Also, added a Git Ignore to clean up git notices on the node_modules after NPM install and the __Temp dir which isn’t needed in VC.